### PR TITLE
Two new backends and a preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This code almost certainly does not work on non-Unix systems, as it relies on Un
 and file ownership to operate. I have no plans to make this work on Windows.
 
 ## Installing It
-
     pip install retemplate
 
 ## Running It
@@ -51,3 +50,68 @@ This would lead to the following behavior:
 * The newly generated template will be compared to the existing one at `/opt/hiapi/config.txt`.
   * If the generated file differs from what is already there, that file will be replaced with the new version. Its ownership and permissions settings will be updated (root:root, 0600). The command `supervisorctl restart hiapi` will be executed.
   * If the two files are the same, retemplate will do nothing.
+
+## Configuration
+Retemplate is configured with a YAML file consisting of three main sections:
+* `retemplate` (global settings)
+* `stores` (data store configuration)
+* `templates` (which files get worked over)
+
+### Global Settings
+Global settings come under the `retemplate` sections. Currently, the only globally adjustable setting is `logging`, wherein you can supply options to pass into the Python logger library's [basicConfig function](https://docs.python.org/3/library/logging.html#logging.basicConfig). [config.yml.example](config.yml.example) shows a few simple options.
+
+### Data Stores
+The `stores` section lets you define your data stores, which are services or functions that retrieve data for templating purposes. There are currently five types of data stores, each with their own configuration options. In the YAML file, these are defined by a dictionary entry where the key is the name of the data store as it will be referenced later in templates and the value is a dictionary of configuration options to be passed into that data store. Although specific configurations may vary between data stores, they all have a `type`, defined below.
+
+#### AWS EC2 Instance Metadata Server
+**type:** *aws-local-meta*
+
+EC2 instances in the AWS cloud have access to a [metadata server](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html) that reveals a handful of useful values for introspection by processes running on those hosts. Configuration is minimal, requiring only the name and type:
+
+    ec2-metadata:
+      type: aws-local-meta
+
+Data is referenced by the URL path used to access it. For example:
+
+    rtpl://ec2-metadata/latest/meta-data/hostname
+
+#### AWS Secrets Manager
+**type:** *aws-secrets-manager*
+
+[Secrets Manager](https://aws.amazon.com/secrets-manager/) is an AWS hosted service for managing access to encrypted secrets. This data store is configured by passing in options to the [boto3 client constructor](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client).
+
+    secrets:
+      type: aws-secrets-manager
+      region_name: us-west-2
+      aws_access_key_id: ABCDEFG
+      aws_secret_access_key: ABCDEFG
+
+Data is referenced by the name of the secret. To retreive the value, the [get_secret_value](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager.html#SecretsManager.Client.get_secret_value) function of boto3 is called, and values referenced in the query portion of the rtpl URI are passed as arguments. For example, you can retrieve a specific secret version like this:
+
+    rtpl://secrets/my.super.duper.secret?VersionId=TheOldOne
+
+#### AWS Systems Manager
+**type:** *aws-systems-manager*
+
+[AWS Systems Manager](https://aws.amazon.com/systems-manager/) is a service intended for making configuration information available to various infrastructure resources in an AWS environment. Retemplate supports using its [parameter store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) as a data source. Like the Secrets Manager store, this is configured using options to the [boto3 client constructor](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client).
+
+    params:
+      type: aws-systems-manager
+      region_name: us-west-2
+
+When referencing values, you can pass parameters to the [get_parameter](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html#SSM.Client.get_parameter) function in the rtpl query string:
+
+    rtpl://params/my.system.parameter?WithDecryption=True
+
+#### Local Execution
+**type:** *local-exec*
+
+This allows Retemplate to run a command on the server it lives on and use the resulting stdout text as a value. This is useful for when the data you need to produce is more complex than a single stored value. It does run as the same user Retemplate does, so be cautious when using this, since Retemplate often needs to run as root. Registering a local execution data store does require that you define the command it's allowed to run. This is a very basic safety measure, but you don't get any security from this aside from deliberation. **Use with caution.**
+
+    timestamp:
+      type: local-exec
+      command: date
+
+The path portion of rtpl URIs gets used as a single argument to the command.
+
+    rtpl://timestamp/

--- a/config.yml.example
+++ b/config.yml.example
@@ -18,6 +18,9 @@ stores:
   ssm:
     type: aws-systems-manager
     region_name: us-west-2
+  timestamp:
+    type: local-exec
+    command: date
 templates:
   /opt/hiapi/config.txt:
     template: /etc/retemplate/hiapi.config.j2

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,6 +4,8 @@ retemplate:
     filename: retemplate.log
     format: '%(levelname)s,%(asctime)s,%(funcName)s,%(message)s'
 stores:
+  ec2-metadata:
+    type: aws-local-meta
   local-redis:
     type: redis
     host: localhost

--- a/rtpl
+++ b/rtpl
@@ -58,12 +58,16 @@ def main():
 
     # Configure DataStores
     for store in config['stores']:
-        if config['stores'][store]['type'] == 'redis':
-            stores[store] = retemplate.RedisStore(store, **config['stores'][store])
+        if config['stores'][store]['type'] == 'aws-local-meta':
+            stores[store] = retemplate.AwsLocalMetadataServer(store, **config['stores'][store])
         if config['stores'][store]['type'] == 'aws-secrets-manager':
             stores[store] = retemplate.AwsSecretsManagerStore(store, **config['stores'][store])
         if config['stores'][store]['type'] == 'aws-systems-manager':
             stores[store] = retemplate.AwsSystemsManagerStore(store, **config['stores'][store])
+        if config['stores'][store]['type'] == 'local-exec':
+            stores[store] = retemplate.LocalExecutionStore(store, **config['stores'][store])
+        if config['stores'][store]['type'] == 'redis':
+            stores[store] = retemplate.RedisStore(store, **config['stores'][store])
         logging.debug('Configured data store {}'.format(store))
 
     # Configure templates

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='retemplate',
-    version='0.0.2',
+    version='0.0.3',
     description="A module to execute a Jinja template on a schedule, supporting several backends for value storage",
     url='https://github.com/ryanjjung/retemplate',
     author='Ryan Jung',


### PR DESCRIPTION
This PR brings in two new backends:
* `local-exec` - Allows retemplate to execute local commands and use their output as values in templates. The command must be pre-configured, and what passes for a "key" in other data sources serves as arguments to the command.
* `aws-local-meta` - Retemplate can converse with the metadata store available on AWS instances at http://169.254.169.254/ and use its responses in templates. This is useful for obtaining host-specific values such as IP address, region, tenancy, etc.

It also introduces a new preproccesing step in which the template can define variables which obtain their values from data stores and use those values as part of later processing. For example, one might use a `local-exec` to run code which determines the environment a host is running in, and later use that environment name as part of an `aws-secrets-manager` store to retrieve an environment-specific value.