### PR TITLE
Make it work for python 36

### DIFF
--- a/retemplate/__init__.py
+++ b/retemplate/__init__.py
@@ -351,9 +351,9 @@ class Retemplate(object):
             if match:
                 groups = match.groups()
                 if groups[1].startswith('rtpl://'):
-                    self.vars[groups[0]] = self.resolve_value(groups[1])
+                    self.vars[groups[0]] = self.resolve_value(groups[1]).strip()
                 else:
-                    self.vars[groups[0]] = groups[1]
+                    self.vars[groups[0]] = groups[1].strip()
                 # Now update all future lines so they get parsed right
                 for j in range(i, len(lines)):
                     for var in self.vars:

--- a/retemplate/__init__.py
+++ b/retemplate/__init__.py
@@ -226,10 +226,7 @@ class LocalExecutionStore(DataStore):
             # Clean these args up a bit
             for i in range(0, len(subp_args)):
                 subp_args[i] = subp_args[i].strip()
-
-            logging.debug('Running command: {}'.format(' '.join(subp_args)))
-            proc = subprocess.run(subp_args, capture_output=True)
-            output = proc.stdout.decode('utf-8').strip()
+            output, _ = self.exec_process(' '.join(subp_args))
             return output
         except Exception as ex:
             logging.error('Failed to get local execution data. Error: {}'.format(ex))
@@ -368,6 +365,20 @@ class Retemplate(object):
                 prerender.append(line)
         return '\n'.join(prerender)
 
+    def exec_process(self, cmd):
+        '''
+        Shells out an external process and gets the stdout/stderr and returncoce.
+        '''
+        logging.debug('Running command: {}'.format(cmd))
+        p = subprocess.Popen(cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
+                             universal_newlines=True,
+                             shell=True)
+        output = p.communicate()[0]
+        returncode = p.returncode
+        return output, returncode
+
     def render(self):
         '''
         Renders a template in three phases:
@@ -439,7 +450,7 @@ class Retemplate(object):
                 shutil.chown(self.target, user=owner, group=group)
             if chmod:
                 logging.info('Setting mode of {} to {}'.format(self.target, chmod))
-                subprocess.run([ 'chmod', self.settings['chmod'], self.target ])
+                self.exec_process(' '.join([ 'chmod', self.settings['chmod'], self.target ]))
             return True
         except IOError:
             logging.error('Cannot write target file {}'.format(self.target))
@@ -459,9 +470,9 @@ class Retemplate(object):
 
         logging.info('Running onchange command \'{}\' for target {}'.format(onchange, self.target))
         try:
-            proc = subprocess.run(onchange.split(' '), capture_output=True)
-            logging.debug('onchange command exited: {}'.format(proc.returncode))
-            logging.debug('onchange command output: {}'.format(proc.stdout))
+            output, returncode = self.exec_process(onchange)
+            logging.debug('onchange command exited: {}'.format(returncode))
+            logging.debug('onchange command output: {}'.format(output))
         except subprocess.CalledProcessError as ex:
             logging.error('[{}] Couldn\'t call process {}'.format(target, onchange))
             logging.error(ex)


### PR DESCRIPTION
By using Popen instead of capture_output=True on the subprocess call, this works for python version 3.6 and 3.7.

The ```.strip()``` call on the value also removes and newlines, which appear on python 3.6, but not on python 3.7.